### PR TITLE
Reposition workbook browse button

### DIFF
--- a/src/costest/gui.py
+++ b/src/costest/gui.py
@@ -163,11 +163,11 @@ class EstimatorApp:
         )
         self.district_combo.grid(row=1, column=1, sticky=tk.EW)
 
-        browse = ttk.Button(container, text="Browse for workbook…", command=self._browse_file)
-        browse.pack(pady=(16, 8))
+        browse = ttk.Button(input_frame, text="Browse for workbook…", command=self._browse_file)
+        browse.grid(row=2, column=0, columnspan=2, sticky=tk.EW, pady=(12, 0))
 
         self.progress = ttk.Progressbar(container, mode="indeterminate")
-        self.progress.pack(fill=tk.X, pady=(0, 12))
+        self.progress.pack(fill=tk.X, pady=(16, 12))
 
         log_label = ttk.Label(container, text="Run log:")
         log_label.pack(anchor=tk.W)


### PR DESCRIPTION
## Summary
- move the workbook browse button into the input section so only one instance is rendered
- adjust the progress bar spacing to suit the new button placement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e47ec72d14832aada4fb1cfb883f92